### PR TITLE
Decode response as utf-8

### DIFF
--- a/jira/listeners/extension_keyword.py
+++ b/jira/listeners/extension_keyword.py
@@ -36,7 +36,7 @@ class ExtensionKeywordListener(EventListener):
 
         try:
             response = urllib.request.urlopen(req)
-            result_types = json.loads(response.read())
+            result_types = json.loads(response.read().decode('utf-8'))
         except urllib.error.HTTPError as e:
             if e.code == 401:
                 results.append(


### PR DESCRIPTION
Without it, I received a TypeError: the JSON object must be str, not 'bytes'.

```
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/ulauncher/api/client/Client.py", line 54, in on_message
    self.extension.trigger_event(event)
  File "/usr/lib/python3/dist-packages/ulauncher/api/client/Extension.py", line 52, in trigger_event
    action = listener.on_event(event, self)
  File "/home/indrek/.local/share/ulauncher/extensions/ulauncher-jira/jira/listeners/extension_keyword.py", line 39, in on_event
    result_types = json.loads(response.read())
  File "/usr/lib/python3.5/json/__init__.py", line 312, in loads
    s.__class__.__name__))
TypeError: the JSON object must be str, not 'bytes'
```

Decoding the response as utf-8 seemed to fix the issue for me. I don't consider myself very fluent in Python, so this change might have some implications that I've not anticipated.